### PR TITLE
Add support to partial read using offset and length to Java client

### DIFF
--- a/bindings/java/src/main/java/org/apache/opendal/AsyncOperator.java
+++ b/bindings/java/src/main/java/org/apache/opendal/AsyncOperator.java
@@ -228,6 +228,11 @@ public class AsyncOperator extends NativeObject {
         return AsyncRegistry.take(requestId);
     }
 
+    public CompletableFuture<byte[]> read(String path, long offset, long len) {
+        final long requestId = read_with_offset(nativeHandle, executorHandle, offset, len, path);
+        return AsyncRegistry.take(requestId);
+    }
+
     public CompletableFuture<PresignedRequest> presignRead(String path, Duration duration) {
         final long requestId = presignRead(nativeHandle, executorHandle, path, duration.toNanos());
         return AsyncRegistry.take(requestId);
@@ -282,6 +287,8 @@ public class AsyncOperator extends NativeObject {
     private static native long constructor(long executorHandle, String scheme, Map<String, String> map);
 
     private static native long read(long nativeHandle, long executorHandle, String path);
+
+    private static native long read_with_offset(long nativeHandle, long executorHandle, long offset, long len, String path);
 
     private static native long write(
             long nativeHandle, long executorHandle, String path, byte[] content, WriteOptions options);

--- a/bindings/java/src/main/java/org/apache/opendal/Operator.java
+++ b/bindings/java/src/main/java/org/apache/opendal/Operator.java
@@ -99,6 +99,10 @@ public class Operator extends NativeObject {
         return read(nativeHandle, path);
     }
 
+    public byte[] read(String path, long offset, long len) {
+        return read_with_offset(nativeHandle, offset, len, path);
+    }
+
     public OperatorInputStream createInputStream(String path) {
         return new OperatorInputStream(this, path);
     }
@@ -139,6 +143,8 @@ public class Operator extends NativeObject {
     private static native void write(long op, String path, byte[] content, WriteOptions options);
 
     private static native byte[] read(long op, String path);
+
+    private static native byte[] read_with_offset(long op, long offset, long len, String path);
 
     private static native void delete(long op, String path);
 

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncReadOnlyTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncReadOnlyTest.java
@@ -119,6 +119,14 @@ public class AsyncReadOnlyTest extends BehaviorTestBase {
         assertEquals(FILE_SHA256_DIGEST, sha256Digest(content));
     }
 
+    @Test
+    public void testReadOnlyReadOffset() throws NoSuchAlgorithmException {
+        final byte[] content = asyncOp().read(NORMAL_FILE_NAME, 0, FILE_LENGTH).join();
+        assertEquals(FILE_LENGTH, content.length);
+
+        assertEquals(FILE_SHA256_DIGEST, sha256Digest(content));
+    }
+
     /**
      * Read full content should match.
      */

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingReadOnlyTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingReadOnlyTest.java
@@ -94,6 +94,13 @@ public class BlockingReadOnlyTest extends BehaviorTestBase {
         assertEquals(FILE_SHA256_DIGEST, sha256Digest(content));
     }
 
+    @Test
+    public void testBlockingReadonlyReadOffset() throws NoSuchAlgorithmException {
+        final byte[] content = op().read(NORMAL_FILE_NAME, 0, FILE_LENGTH);
+        assertEquals(FILE_LENGTH, content.length);
+        assertEquals(FILE_SHA256_DIGEST, sha256Digest(content));
+    }
+
     /**
      * Read not exist file should return NotFound
      */


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

Exposes reading part of a file using offset and length in the Java API.

# What changes are included in this PR?

1. Added API in Java and native binding
2. Added implementation in native binding to expose offset reading

# Are there any user-facing changes?

Operator.java:
```
byte[] read(String path, long offset, long len)
```
AsyncOperator.java:
```
public CompletableFuture<byte[]> read(String path, long offset, long len)
```
